### PR TITLE
LockscreenUI: Fix default lock clock font

### DIFF
--- a/src/com/bootleggers/dumpster/external/LockscreenUI.java
+++ b/src/com/bootleggers/dumpster/external/LockscreenUI.java
@@ -54,7 +54,7 @@ public class LockscreenUI extends SettingsPreferenceFragment implements
 
         mLockClockFonts = (ListPreference) findPreference(LOCK_CLOCK_FONTS);
         mLockClockFonts.setValue(String.valueOf(Settings.System.getInt(
-                getContentResolver(), Settings.System.LOCK_CLOCK_FONTS, 0)));
+                getContentResolver(), Settings.System.LOCK_CLOCK_FONTS, 21)));
         mLockClockFonts.setSummary(mLockClockFonts.getEntry());
         mLockClockFonts.setOnPreferenceChangeListener(this);
 


### PR DESCRIPTION
in base: private int getLockClockFont() {
        return Settings.System.getInt(mContext.getContentResolver(),
                Settings.System.LOCK_CLOCK_FONTS, 21);
}